### PR TITLE
Only run Deploy Workflow when Build was successful

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -3,13 +3,15 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - develop
+  workflow_run:
+    workflows: [ "Build" ]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # run when triggered by workflow_dispatch, otherwise only run when Build was successful
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
@stefanseifert this is an example for chaining the workflows. This seems only work when the file is also on the default branch.
See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run

